### PR TITLE
ci: Don't test the `develop` branch of `qmk/qmk_firmware`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
             // Default settings.
             const defaultSource = [
               { repo: "qmk/qmk_firmware", branch: "master" },
-              { repo: "qmk/qmk_firmware", branch: "develop" },
+              // Not compatible with gcc-arm-none-eabi-7-2018-q2-update since
+              // https://github.com/qmk/qmk_firmware/pull/21656 had been merged
+              // (`_Alignas` in compound literals requires GCC >= 8.x).
+              // { repo: "qmk/qmk_firmware", branch: "develop" },
             ];
 
             // Read workflow inputs.


### PR DESCRIPTION
Unfortunately, the code from the `develop` branch can't be compiled using `gcc-arm-none-eabi-7-2018-q2-update`, which is the newest version of the ARM toolchain available in Guix at the moment.  The problem is that the code from https://www.github.com/qmk/qmk_firmware/pull/21656 uses `_Alignas` in compound literals, which requires GCC >= 8.x.

Disable tests for the `develop` branch in CI; this will keep it working until the next round of breaking changes merge in QMK, at which point the ARM support would need to be dropped until a more recent version of the ARM embedded toolchain appears in Guix.